### PR TITLE
Added new syntax: "emit" prefix to Creation event in contract.

### DIFF
--- a/contracts/SplitIt.sol
+++ b/contracts/SplitIt.sol
@@ -58,7 +58,7 @@ contract SplitItCreator {
 
   function createSplitIt(address[] receivingAddresses) public {
     SplitIt splitIt = new SplitIt(receivingAddresses);
-    Creation(splitIt);
+    emit Creation(splitIt);
   }
 
 }


### PR DESCRIPTION
The reason why I was having trouble publishing the contract on the test net was because there is a new syntax for events ( https://github.com/ethereum/solidity/issues/2877 )

In order for them not to be confused with functions you say "emit" before the event.

It is now fixed.

Published on the rinkeby using this latest syntax from the repo at 0x7Ec92Ee4b0c22571F65A51575bAB62a4C43bBcEE