### PR TITLE
29 remove source mapping

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -52,7 +52,8 @@ module.exports = {
   bail: true,
   // We generate sourcemaps in production. This is slow but gives good results.
   // You can exclude the *.map files from the build during deployment.
-  devtool: 'source-map',
+  // Uncomment the next line to turn on source maps in the build
+  // devtool: 'source-map',
   // In production, we only want to load the polyfills and the app code.
   entry: [
     require.resolve('./polyfills'),


### PR DESCRIPTION
- disables source maps so Chinese webcrawlers can't clone our app without visiting our repo first

