### PR TITLE
50 fix background scrolling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,9 +16,9 @@
     <title>Split It</title>
   </head>
   <body>
-    <div id="background">
-      <div id="root"></div>
-    </div>
+    <!-- <div id="background"> -->
+    <div id="root"></div>
+    <!-- </div> -->
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/public/index.html
+++ b/public/index.html
@@ -16,9 +16,7 @@
     <title>Split It</title>
   </head>
   <body>
-    <!-- <div id="background"> -->
     <div id="root"></div>
-    <!-- </div> -->
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ const RoutesContainer = styled.div`
 const Header = styled.header`
   display: flex;
   flex: 1 0;
+  min-height: 60px;
   width: 100%;
   background-color: ${colors.navbar_bg};
   justify-content: space-between;

--- a/src/_Create/AddressesPane.jsx
+++ b/src/_Create/AddressesPane.jsx
@@ -17,7 +17,7 @@ import './index.css';
 
 
 const Container = styled.div`
-  flex: 1 0;
+  flex: 1 1 auto;
   display: flex;
   max-width: 100%;
   flex-direction: column;
@@ -26,7 +26,7 @@ const Container = styled.div`
 const InnerContainer = styled.div`
 `
 const AddButton = BaseButtonBlue.extend`
-  height: 45px;
+  min-height: 45px;
   font-size: 1.2em;
   border-radius: 0 0 5px 5px;
   border-top: none;

--- a/src/components/TopLevelComponents.styled.js
+++ b/src/components/TopLevelComponents.styled.js
@@ -18,6 +18,7 @@ export const TopArea = styled.div`
   display: flex;
   width: 100%;
   flex: 1 1;
+  min-height: 68px;
   font-size: 1.2em;
   flex-direction: row;
   align-items: center;
@@ -75,7 +76,7 @@ export const NotConnectedPane = styled.div`
   background-color: red;
 `
 export const ContentArea = styled.div`
-  flex: 12 1;
+  flex: 12 0 auto;
   display: flex;
   width: 100%;
   border-radius: 5px;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,12 +4,12 @@ body {
   font-family: Roboto, sans-serif;
   display: flex;
   background-color: #2A2A2A !important;
+  justify-content: center;
 }
 
 #background {
   display: flex;
   flex: 1 0;
-  justify-content: center;
 }
 
 #root {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,19 +2,21 @@ body {
   margin: 0;
   padding: 0;
   font-family: Roboto, sans-serif;
+  display: flex;
+  background-color: #2A2A2A !important;
 }
 
 #background {
-  background-color: #2A2A2A !important;
   display: flex;
+  flex: 1 0;
   justify-content: center;
-  height: 100vh;
 }
 
 #root {
   display: flex;
   flex: 1 0;
   max-width: 1000px;
+  min-height: 100vh;
 }
 
 @font-face {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,11 +7,6 @@ body {
   justify-content: center;
 }
 
-#background {
-  display: flex;
-  flex: 1 0;
-}
-
 #root {
   display: flex;
   flex: 1 0;


### PR DESCRIPTION
- removes `#background` div that was handling background color and put background color on `body`
- adds `min-height` attributes to `TopArea` and `AddButton` so they don't shrink as addresslist extends to upper and lower view boundaries